### PR TITLE
Remove batch limit in training cc2ftr for JIT Defect Prediction

### DIFF
--- a/jit_cc2ftr_train.py
+++ b/jit_cc2ftr_train.py
@@ -29,7 +29,6 @@ def train_model(data, params):
 
     optimizer = torch.optim.Adam(model.parameters(), lr=params.l2_reg_lambda)
     criterion = nn.BCEWithLogitsLoss()
-    batches = batches[:10]
     for epoch in range(1, params.num_epochs + 1):
         total_loss = 0
         for i, (batch) in enumerate(tqdm(batches)):


### PR DESCRIPTION
There seems to be a bug in this file, where the training batches are limited to only the first 10 batches. This means the model is only trained on a very small subset of the dataset. The fact that no such batch limit occurs in the other two applications of CC2Vec, leads me to believe this is unintended.